### PR TITLE
do a 'contains' search in the datadog monitor name when trying to find the team

### DIFF
--- a/dash-core/src/main/java/de/axelspringer/ideas/tools/dash/business/datadog/DataDogCheckExecutor.java
+++ b/dash-core/src/main/java/de/axelspringer/ideas/tools/dash/business/datadog/DataDogCheckExecutor.java
@@ -56,7 +56,6 @@ public class DataDogCheckExecutor implements CheckExecutor<DataDogCheck> {
 
     CheckResult convertMonitorToCheckResult(DataDogMonitor monitor, DataDogCheck check, DataDogDowntimes downtimes) {
         Group group = check.getGroup();
-        String nameFilter = check.getNameFilter();
         Map<String, Team> jobNameTeamMappings = check.getJobNameTeamMappings();
 
         State state = monitor.isOverallStateOk() ? State.GREEN : State.RED;
@@ -72,7 +71,7 @@ public class DataDogCheckExecutor implements CheckExecutor<DataDogCheck> {
         }
 
         final CheckResult checkResult = new CheckResult(state, monitor.getName() + "@DataDog", infoMessage, 1, errorCount, group);
-        final Team team = decideTeam(monitor.getName(), nameFilter, jobNameTeamMappings);
+        final Team team = decideTeam(monitor.getName(), jobNameTeamMappings);
         if (team != null) {
             checkResult.withTeam(team);
         }
@@ -82,17 +81,14 @@ public class DataDogCheckExecutor implements CheckExecutor<DataDogCheck> {
         return checkResult;
     }
 
-    Team decideTeam(String monitorName, String nameFilter, Map<String, Team> jobNameTeamMappings) {
+    Team decideTeam(String monitorName, Map<String, Team> jobNameTeamMappings) {
 
         // operate on this string
-        String strippedName = monitorName.toLowerCase();
-
-        // remove name filter
-        strippedName = nameFilter != null && strippedName.startsWith(nameFilter.toLowerCase()) ? strippedName.substring(nameFilter.length()) : strippedName;
+        monitorName = monitorName.toLowerCase();
 
         // search for team mapping
         for (String teamName : jobNameTeamMappings.keySet()) {
-            if (strippedName.startsWith(teamName.toLowerCase())) {
+            if (monitorName.contains(teamName.toLowerCase())) {
                 return jobNameTeamMappings.get(teamName);
             }
         }

--- a/dash-core/src/test/java/de/axelspringer/ideas/tools/dash/business/datadog/DataDogCheckExecutorTest.java
+++ b/dash-core/src/test/java/de/axelspringer/ideas/tools/dash/business/datadog/DataDogCheckExecutorTest.java
@@ -161,10 +161,11 @@ public class DataDogCheckExecutorTest {
     @Test
     public void decideTeam() {
 
-        assertNull(dataDogCheckExecutor.decideTeam("[yana][cm]some_monitor", null, teamMappings()));
-        assertNull(dataDogCheckExecutor.decideTeam("[yana][foo]some_monitor", "[yana]", teamMappings()));
-        assertNull(dataDogCheckExecutor.decideTeam("some_monitor", null, teamMappings()));
-        assertEquals(TestTeam.INSTANCE, dataDogCheckExecutor.decideTeam("[yana][cm]some_monitor", "[yana]", teamMappings()));
+        assertNull(dataDogCheckExecutor.decideTeam("[foo]some_monitor", teamMappings()));
+        assertNull(dataDogCheckExecutor.decideTeam("some_monitor", teamMappings()));
+        assertEquals(TestTeam.INSTANCE, dataDogCheckExecutor.decideTeam("[yana][cm]some_monitor", teamMappings()));
+        assertEquals(TestTeam.INSTANCE, dataDogCheckExecutor.decideTeam("[yana][foo][cm]some_monitor", teamMappings()));
+        assertEquals(TestTeam.INSTANCE, dataDogCheckExecutor.decideTeam("[cm]some_monitor", teamMappings()));
     }
 
     private DataDogDowntimes downtimes() {


### PR DESCRIPTION
… for more flexibility

Sometimes monitors are called '[project][foo][team1]' instead of '[project][team1]' but both belong to team1