### PR TITLE
datadog monitors in state "No Data" and "notify_no_data: false" should not be red

### DIFF
--- a/dash-core/src/main/java/de/axelspringer/ideas/tools/dash/business/datadog/DataDogMonitor.java
+++ b/dash-core/src/main/java/de/axelspringer/ideas/tools/dash/business/datadog/DataDogMonitor.java
@@ -13,6 +13,7 @@ import java.util.regex.Pattern;
 public class DataDogMonitor {
 
     public final static String STATE_OK = "OK";
+    public final static String STATE_NO_DATA = "No Data";
 
     // This is the inner data from the JSON
     private String name;
@@ -54,7 +55,15 @@ public class DataDogMonitor {
         return options == null || !options.isSilenced();
     }
 
+    public boolean isNotifyNoData() {
+        return options != null && options.isNotifyNoData();
+    }
+
     public boolean isOverallStateOk() {
+        if (!isNotifyNoData() && STATE_NO_DATA.equals(overallState)) {
+            // the overall state is ok if the state is "No Data" and the monitor is *not* set up to notify on no data
+            return true;
+        }
         return STATE_OK.equals(overallState);
     }
 

--- a/dash-core/src/main/java/de/axelspringer/ideas/tools/dash/business/datadog/DataDogMonitorOptions.java
+++ b/dash-core/src/main/java/de/axelspringer/ideas/tools/dash/business/datadog/DataDogMonitorOptions.java
@@ -1,22 +1,37 @@
 package de.axelspringer.ideas.tools.dash.business.datadog;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.Map;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class DataDogMonitorOptions {
 
-    private Boolean notify_no_data;
-    private Boolean notify_audit;
-    private Boolean is_data_sparse;
+    @JsonProperty("notify_no_data")
+    private Boolean notifyNoData;
 
-    private Long renotify_interval;
-    private Long no_data_timeframe;
-    private Long timeout_h;
-    private Long silenced_timeout_ts;
+    @JsonProperty("notify_audit")
+    private Boolean notifyAudit;
 
-    private String escalation_message;
+    @JsonProperty("is_data_sparse")
+    private Boolean isDataSparse;
+
+    @JsonProperty("renotify_interval")
+    private Long renotifyInterval;
+
+    @JsonProperty("no_data_timeframe")
+    private Long noDataTimeframe;
+
+    @JsonProperty("timeout_h")
+    private Long timeoutH;
+
+    @JsonProperty("silenced_timeout_ts")
+    private Long silencedTimeoutTs;
+
+    @JsonProperty("escalation_message")
+    private String escalationMessage;
+
     private Map<String, Object> silenced;
 
     public boolean isSilenced() {
@@ -24,5 +39,9 @@ public class DataDogMonitorOptions {
             return true;
         }
         return false;
+    }
+
+    public boolean isNotifyNoData() {
+        return (notifyNoData != null && notifyNoData);
     }
 }

--- a/dash-core/src/test/java/de/axelspringer/ideas/tools/dash/business/datadog/DataDogCheckExecutorTest.java
+++ b/dash-core/src/test/java/de/axelspringer/ideas/tools/dash/business/datadog/DataDogCheckExecutorTest.java
@@ -49,7 +49,7 @@ public class DataDogCheckExecutorTest {
     public void executeCheck_AllResultsOk() throws Exception {
 
         // simulate successful backend call
-        when(restTemplate.getForEntity(anyString(), eq(DataDogMonitor[].class))).thenReturn(new ResponseEntity<>(new DataDogMonitor[]{dataDogMonitor("Monitor OK", DataDogMonitor.STATE_OK), dataDogMonitor("Monitor in Error", "some_error_state")}, HttpStatus.OK));
+        mockDatadogApiCallAndReturn(dataDogMonitor("Monitor OK", DataDogMonitor.STATE_OK), dataDogMonitor("Monitor in Error", "some_error_state"));
 
         // execute check
         final List<CheckResult> checkResults = dataDogCheckExecutor.executeCheck(new DataDogCheck("myCheck", null, null, null, null));
@@ -68,10 +68,40 @@ public class DataDogCheckExecutorTest {
     }
 
     @Test
+    public void executeCheck_noDataMonitor() throws Exception {
+
+        // simulate successful backend call
+        mockDatadogApiCallAndReturn(dataDogMonitor("Monitor OK", DataDogMonitor.STATE_NO_DATA));
+
+        // execute check
+        final List<CheckResult> checkResults = dataDogCheckExecutor.executeCheck(new DataDogCheck("myCheck", null, null, null, null));
+
+        assertEquals(1, checkResults.size());
+        assertEquals(State.GREEN, checkResults.get(0).getState());
+        assertEquals("Monitor OK@DataDog", checkResults.get(0).getName());
+        assertEquals("No Data (query: null)", checkResults.get(0).getInfo());
+    }
+
+    @Test
+    public void executeCheck_noDataMonitor_withNotifyNoData() throws Exception {
+
+        // simulate successful backend call
+        mockDatadogApiCallAndReturn(enableNotifyNoData(dataDogMonitor("Monitor not OK", DataDogMonitor.STATE_NO_DATA)));
+
+        // execute check
+        final List<CheckResult> checkResults = dataDogCheckExecutor.executeCheck(new DataDogCheck("myCheck", null, null, null, null));
+
+        assertEquals(1, checkResults.size());
+        assertEquals(State.RED, checkResults.get(0).getState());
+        assertEquals("Monitor not OK@DataDog", checkResults.get(0).getName());
+        assertEquals("No Data (query: null)", checkResults.get(0).getInfo());
+    }
+
+    @Test
     public void executeCheck_WithNameFiler() throws Exception {
 
         // simulate successful backend call
-        when(restTemplate.getForEntity(anyString(), eq(DataDogMonitor[].class))).thenReturn(new ResponseEntity<>(new DataDogMonitor[]{dataDogMonitor("[YANA]Monitor OK", DataDogMonitor.STATE_OK), dataDogMonitor("Monitor in Error", "some_error_state")}, HttpStatus.OK));
+        mockDatadogApiCallAndReturn(dataDogMonitor("[YANA]Monitor OK", DataDogMonitor.STATE_OK), dataDogMonitor("Monitor in Error", "some_error_state"));
 
         // execute check with name filter (should work case-insensitive)
         final List<CheckResult> checkResults = dataDogCheckExecutor.executeCheck(new DataDogCheck("myCheck", null, null, null, "[yana]"));
@@ -86,7 +116,7 @@ public class DataDogCheckExecutorTest {
     public void executeCheck_WithHttpError() throws Exception {
 
         // simulate some code other than 200
-        when(restTemplate.getForEntity(anyString(), eq(DataDogMonitor[].class))).thenReturn(new ResponseEntity<>(HttpStatus.BAD_GATEWAY));
+        mockDatadogApiCallAndReturn(HttpStatus.BAD_GATEWAY);
 
         // execute check
         final List<CheckResult> checkResults = dataDogCheckExecutor.executeCheck(mock(DataDogCheck.class));
@@ -182,10 +212,25 @@ public class DataDogCheckExecutorTest {
         return monitor;
     }
 
+    private DataDogMonitor enableNotifyNoData(DataDogMonitor monitor) {
+        DataDogMonitorOptions options = new DataDogMonitorOptions();
+        Whitebox.setInternalState(options, "notifyNoData", true);
+        Whitebox.setInternalState(monitor, "options", options);
+        return monitor;
+    }
+
     private Map<String, Team> teamMappings() {
 
         Map<String, Team> teamMappings = new HashMap<>();
         teamMappings.put("[cm]", TestTeam.INSTANCE);
         return teamMappings;
+    }
+
+    private void mockDatadogApiCallAndReturn(DataDogMonitor... monitors) {
+        when(restTemplate.getForEntity(anyString(), eq(DataDogMonitor[].class))).thenReturn(new ResponseEntity<>(monitors, HttpStatus.OK));
+    }
+
+    private void mockDatadogApiCallAndReturn(HttpStatus httpStatus) {
+        when(restTemplate.getForEntity(anyString(), eq(DataDogMonitor[].class))).thenReturn(new ResponseEntity<>(httpStatus));
     }
 }

--- a/dash-core/src/test/java/de/axelspringer/ideas/tools/dash/business/datadog/DataDogMonitorTest.java
+++ b/dash-core/src/test/java/de/axelspringer/ideas/tools/dash/business/datadog/DataDogMonitorTest.java
@@ -18,6 +18,7 @@ import java.util.List;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.doReturn;
 
 public class DataDogMonitorTest {
@@ -67,6 +68,8 @@ public class DataDogMonitorTest {
 
         assertNotNull(dataDogMonitor.getOptions());
         assertNotNull(dataDogMonitor.getOverallState());
+        assertTrue(dataDogMonitor.isSilencedMonitor());
+        assertTrue(dataDogMonitor.isNotifyNoData());
     }
 
 


### PR DESCRIPTION
do not mark a datadog monitor as red if it is in the state "No Data" but "notify on no data" is disabled