### PR TITLE
refactor out mapping the datadog monitor to a checkresult

### DIFF
--- a/dash-core/src/main/java/de/axelspringer/ideas/tools/dash/DashConfig.java
+++ b/dash-core/src/main/java/de/axelspringer/ideas/tools/dash/DashConfig.java
@@ -1,6 +1,7 @@
 package de.axelspringer.ideas.tools.dash;
 
 import com.google.gson.Gson;
+import de.axelspringer.ideas.tools.dash.business.datadog.DataDogConfig;
 import de.axelspringer.ideas.tools.dash.business.jira.JiraConfig;
 import de.axelspringer.ideas.tools.dash.config.ClientConfig;
 import org.springframework.context.annotation.Bean;
@@ -12,7 +13,7 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 @Configuration
 @EnableScheduling
 @ComponentScan(basePackages = "de.axelspringer.ideas.tools.dash", excludeFilters = @ComponentScan.Filter(Configuration.class))
-@Import({ClientConfig.class, JiraConfig.class})
+@Import({ClientConfig.class, JiraConfig.class, DataDogConfig.class})
 public class DashConfig {
 
     @Bean

--- a/dash-core/src/main/java/de/axelspringer/ideas/tools/dash/business/datadog/DataDogCheck.java
+++ b/dash-core/src/main/java/de/axelspringer/ideas/tools/dash/business/datadog/DataDogCheck.java
@@ -2,11 +2,6 @@ package de.axelspringer.ideas.tools.dash.business.datadog;
 
 import de.axelspringer.ideas.tools.dash.business.check.AbstractCheck;
 import de.axelspringer.ideas.tools.dash.business.customization.Group;
-import de.axelspringer.ideas.tools.dash.business.customization.Team;
-
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
 
 public class DataDogCheck extends AbstractCheck {
 
@@ -16,7 +11,6 @@ public class DataDogCheck extends AbstractCheck {
     private final String appKey;
 
     private final String nameFilter;
-    private Map<String, Team> jobNameTeamMappings = new HashMap<>();
 
     public DataDogCheck(String name, Group group, String apiKey, String appKey, String nameFilter) {
 
@@ -41,14 +35,5 @@ public class DataDogCheck extends AbstractCheck {
     @Override
     public String getIconSrc() {
         return ICON_SRC;
-    }
-
-    public Map<String, Team> getJobNameTeamMappings() {
-        return Collections.unmodifiableMap(jobNameTeamMappings);
-    }
-
-    public DataDogCheck withJobNameTeamMapping(String jobName, Team team) {
-        jobNameTeamMappings.put(jobName, team);
-        return this;
     }
 }

--- a/dash-core/src/main/java/de/axelspringer/ideas/tools/dash/business/datadog/DataDogCheckExecutor.java
+++ b/dash-core/src/main/java/de/axelspringer/ideas/tools/dash/business/datadog/DataDogCheckExecutor.java
@@ -3,8 +3,7 @@ package de.axelspringer.ideas.tools.dash.business.datadog;
 import de.axelspringer.ideas.tools.dash.business.check.Check;
 import de.axelspringer.ideas.tools.dash.business.check.CheckExecutor;
 import de.axelspringer.ideas.tools.dash.business.check.CheckResult;
-import de.axelspringer.ideas.tools.dash.business.customization.Group;
-import de.axelspringer.ideas.tools.dash.business.customization.Team;
+import de.axelspringer.ideas.tools.dash.business.datadog.monitorresultmapper.MonitorResultMapper;
 import de.axelspringer.ideas.tools.dash.presentation.State;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -17,7 +16,6 @@ import org.springframework.web.client.RestTemplate;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 
 @Service
@@ -27,9 +25,11 @@ public class DataDogCheckExecutor implements CheckExecutor<DataDogCheck> {
     @Qualifier("exceptionSwallowingRestTemplate")
     private RestTemplate restTemplate;
 
+    @Autowired
+    private MonitorResultMapper monitorResultMapper;
+
     @Override
     public List<CheckResult> executeCheck(DataDogCheck check) {
-
 
         final ResponseEntity<DataDogMonitor[]> monitorResponse = loadFromDataDog(check.getApiKey(), check.getAppKey());
         final DataDogDowntimes downtimes = new DataDogDowntimes(restTemplate, check.getApiKey(), check.getAppKey());
@@ -40,7 +40,7 @@ public class DataDogCheckExecutor implements CheckExecutor<DataDogCheck> {
 
         return Arrays.asList(monitorResponse.getBody()).stream()
                 .filter(candidate -> isNameMatching(check, candidate))
-                .map(monitor -> convertMonitorToCheckResult(monitor, check, downtimes))
+                .map(monitor -> monitorResultMapper.mapToResult(monitor, check, downtimes))
                 .collect(Collectors.toList());
     }
 
@@ -52,48 +52,6 @@ public class DataDogCheckExecutor implements CheckExecutor<DataDogCheck> {
 
     private boolean isNameMatching(DataDogCheck check, DataDogMonitor candidate) {
         return StringUtils.isEmpty(check.getNameFilter()) || candidate.getName().toLowerCase().contains(check.getNameFilter().toLowerCase());
-    }
-
-    CheckResult convertMonitorToCheckResult(DataDogMonitor monitor, DataDogCheck check, DataDogDowntimes downtimes) {
-        Group group = check.getGroup();
-        Map<String, Team> jobNameTeamMappings = check.getJobNameTeamMappings();
-
-        String infoMessage = monitor.getOverallState() + " (query: " + monitor.getQuery() + ")";
-        State state = State.RED;
-
-        if (monitor.isOverallStateOk()) {
-            state = State.GREEN;
-        } else if (monitor.isSilencedMonitor()) {
-            state = State.GREEN;
-            infoMessage = "NOT ACTIVE (silenced)!";
-        } else if (downtimes.hasDowntime(monitor)) {
-            state = State.GREEN;
-            infoMessage = "MAINTENANCE!";
-        }
-
-        final CheckResult checkResult = new CheckResult(state, monitor.getName() + "@DataDog", infoMessage, 1, State.GREEN == state ? 0 : 1, group);
-        final Team team = decideTeam(monitor.getName(), jobNameTeamMappings);
-        if (team != null) {
-            checkResult.withTeam(team);
-        }
-
-        // HINT https://app.datadoghq.com/monitors#status?id=182437&group=all
-        checkResult.withLink("https://app.datadoghq.com/monitors#status?id=" + monitor.getId() + "&group=all");
-        return checkResult;
-    }
-
-    Team decideTeam(String monitorName, Map<String, Team> jobNameTeamMappings) {
-
-        // operate on this string
-        monitorName = monitorName.toLowerCase();
-
-        // search for team mapping
-        for (String teamName : jobNameTeamMappings.keySet()) {
-            if (monitorName.contains(teamName.toLowerCase())) {
-                return jobNameTeamMappings.get(teamName);
-            }
-        }
-        return null;
     }
 
     @Override

--- a/dash-core/src/main/java/de/axelspringer/ideas/tools/dash/business/datadog/DataDogConfig.java
+++ b/dash-core/src/main/java/de/axelspringer/ideas/tools/dash/business/datadog/DataDogConfig.java
@@ -1,0 +1,17 @@
+package de.axelspringer.ideas.tools.dash.business.datadog;
+
+import de.axelspringer.ideas.tools.dash.business.datadog.monitorresultmapper.DefaultMonitorResultMapper;
+import de.axelspringer.ideas.tools.dash.business.datadog.monitorresultmapper.MonitorResultMapper;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class DataDogConfig {
+
+    @ConditionalOnMissingBean
+    @Bean
+    public MonitorResultMapper monitorStateMapper() {
+        return new DefaultMonitorResultMapper();
+    }
+}

--- a/dash-core/src/main/java/de/axelspringer/ideas/tools/dash/business/datadog/DataDogMonitor.java
+++ b/dash-core/src/main/java/de/axelspringer/ideas/tools/dash/business/datadog/DataDogMonitor.java
@@ -67,6 +67,10 @@ public class DataDogMonitor {
         return STATE_OK.equals(overallState);
     }
 
+    public boolean isTriggeredConsideringDowntimes(DataDogDowntimes downtimes) {
+        return !isOverallStateOk() && !isSilencedMonitor() && !downtimes.hasDowntime(this);
+    }
+
     public List<String> getTags() {
         if (tags == null) {
             tags = findAllTagsInQuery();

--- a/dash-core/src/main/java/de/axelspringer/ideas/tools/dash/business/datadog/monitorresultmapper/DefaultMonitorResultMapper.java
+++ b/dash-core/src/main/java/de/axelspringer/ideas/tools/dash/business/datadog/monitorresultmapper/DefaultMonitorResultMapper.java
@@ -1,0 +1,37 @@
+package de.axelspringer.ideas.tools.dash.business.datadog.monitorresultmapper;
+
+import de.axelspringer.ideas.tools.dash.business.check.CheckResult;
+import de.axelspringer.ideas.tools.dash.business.customization.Group;
+import de.axelspringer.ideas.tools.dash.business.datadog.DataDogCheck;
+import de.axelspringer.ideas.tools.dash.business.datadog.DataDogDowntimes;
+import de.axelspringer.ideas.tools.dash.business.datadog.DataDogMonitor;
+import de.axelspringer.ideas.tools.dash.presentation.State;
+
+public class DefaultMonitorResultMapper implements MonitorResultMapper {
+
+    public CheckResult mapToResult(DataDogMonitor monitor, DataDogCheck check, DataDogDowntimes downtimes) {
+        final Group group = check.getGroup();
+        final String infoMessage = decideInfoMessage(monitor, downtimes);
+        final State state = decideState(monitor, downtimes);
+
+        final CheckResult checkResult = new CheckResult(state, monitor.getName(), infoMessage, 1, State.GREEN == state ? 0 : 1, group);
+
+        // HINT https://app.datadoghq.com/monitors#status?id=182437&group=all
+        checkResult.withLink("https://app.datadoghq.com/monitors#status?id=" + monitor.getId() + "&group=all");
+        return checkResult;
+    }
+
+    protected String decideInfoMessage(DataDogMonitor monitor, DataDogDowntimes downtimes) {
+        if (monitor.isSilencedMonitor()) {
+            return "NOT ACTIVE (silenced)!";
+        } else if (downtimes.hasDowntime(monitor)) {
+            return "MAINTENANCE!";
+        } else {
+            return monitor.getOverallState();
+        }
+    }
+
+    protected State decideState(DataDogMonitor monitor, DataDogDowntimes downtimes) {
+        return monitor.isTriggeredConsideringDowntimes(downtimes) ? State.RED : State.GREEN;
+    }
+}

--- a/dash-core/src/main/java/de/axelspringer/ideas/tools/dash/business/datadog/monitorresultmapper/MonitorResultMapper.java
+++ b/dash-core/src/main/java/de/axelspringer/ideas/tools/dash/business/datadog/monitorresultmapper/MonitorResultMapper.java
@@ -1,0 +1,11 @@
+package de.axelspringer.ideas.tools.dash.business.datadog.monitorresultmapper;
+
+import de.axelspringer.ideas.tools.dash.business.check.CheckResult;
+import de.axelspringer.ideas.tools.dash.business.datadog.DataDogCheck;
+import de.axelspringer.ideas.tools.dash.business.datadog.DataDogDowntimes;
+import de.axelspringer.ideas.tools.dash.business.datadog.DataDogMonitor;
+
+public interface MonitorResultMapper {
+
+    CheckResult mapToResult(DataDogMonitor monitor, DataDogCheck check, DataDogDowntimes downtimes);
+}

--- a/dash-core/src/test/java/de/axelspringer/ideas/tools/dash/business/datadog/DataDogCheckExecutorTest.java
+++ b/dash-core/src/test/java/de/axelspringer/ideas/tools/dash/business/datadog/DataDogCheckExecutorTest.java
@@ -1,125 +1,101 @@
 package de.axelspringer.ideas.tools.dash.business.datadog;
 
-import de.axelspringer.ideas.tools.dash.TestTeam;
 import de.axelspringer.ideas.tools.dash.business.check.CheckResult;
-import de.axelspringer.ideas.tools.dash.business.customization.Team;
+import de.axelspringer.ideas.tools.dash.business.datadog.monitorresultmapper.DefaultMonitorResultMapper;
+import de.axelspringer.ideas.tools.dash.config.ClientConfig;
 import de.axelspringer.ideas.tools.dash.presentation.State;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.internal.util.reflection.Whitebox;
 import org.mockito.runners.MockitoJUnitRunner;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
 import org.springframework.web.client.RestTemplate;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyObject;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withBadRequest;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
 
 @RunWith(MockitoJUnitRunner.class)
 public class DataDogCheckExecutorTest {
 
+    private static final CheckResult result = new CheckResult(State.GREEN, "name", "info", 1, 0, null);;
+
     @Mock
-    private RestTemplate restTemplate;
+    private DefaultMonitorResultMapper monitorResultMapper;
 
     @InjectMocks
     private DataDogCheckExecutor dataDogCheckExecutor;
 
+    private MockRestServiceServer mockServer;
+
     @Before
     public void beforeMethod() throws Exception {
-        doReturn(new ResponseEntity<>(HttpStatus.CONFLICT)).when(restTemplate).getForEntity(anyString(), anyObject());
+        RestTemplate restTemplate = new ClientConfig().exceptionSwallowingRestTemplate();
+        Whitebox.setInternalState(dataDogCheckExecutor, "restTemplate", restTemplate);
+        mockServer = MockRestServiceServer.createServer(restTemplate);
+
+        when(monitorResultMapper.mapToResult(any(DataDogMonitor.class), any(DataDogCheck.class), any(DataDogDowntimes.class))).thenReturn(result);
     }
 
     @Test
     public void executeCheck_AllResultsOk() throws Exception {
 
-        // simulate successful backend call
-        mockDatadogApiCallAndReturn(dataDogMonitor("Monitor OK", DataDogMonitor.STATE_OK), dataDogMonitor("Monitor in Error", "some_error_state"));
+        mockServer.expect(requestTo("https://app.datadoghq.com/api/v1/monitor?api_key=apikey&application_key=appkey"))
+                .andExpect(method(HttpMethod.GET))
+                .andRespond(withSuccess("[{},{}]", MediaType.APPLICATION_JSON));
+
+        mockDowntimesRestCall();
 
         // execute check
-        final List<CheckResult> checkResults = dataDogCheckExecutor.executeCheck(new DataDogCheck("myCheck", null, null, null, null));
+        final List<CheckResult> checkResults = dataDogCheckExecutor.executeCheck(check(null));
+
+        mockServer.verify();
 
         assertEquals(2, checkResults.size());
-
-        final List<CheckResult> red = checkResults.stream().filter((checkResult) -> State.RED == checkResult.getState()).collect(Collectors.toList());
-        assertEquals(1, red.size());
-        assertEquals("Monitor in Error@DataDog", red.get(0).getName());
-        assertEquals("some_error_state (query: null)", red.get(0).getInfo());
-
-        final List<CheckResult> green = checkResults.stream().filter((checkResult) -> State.GREEN == checkResult.getState()).collect(Collectors.toList());
-        assertEquals(1, green.size());
-        assertEquals("Monitor OK@DataDog", green.get(0).getName());
-        assertEquals("OK (query: null)", green.get(0).getInfo());
-    }
-
-    @Test
-    public void executeCheck_noDataMonitor() throws Exception {
-
-        // simulate successful backend call
-        mockDatadogApiCallAndReturn(dataDogMonitor("Monitor OK", DataDogMonitor.STATE_NO_DATA));
-
-        // execute check
-        final List<CheckResult> checkResults = dataDogCheckExecutor.executeCheck(new DataDogCheck("myCheck", null, null, null, null));
-
-        assertEquals(1, checkResults.size());
-        assertEquals(State.GREEN, checkResults.get(0).getState());
-        assertEquals("Monitor OK@DataDog", checkResults.get(0).getName());
-        assertEquals("No Data (query: null)", checkResults.get(0).getInfo());
-    }
-
-    @Test
-    public void executeCheck_noDataMonitor_withNotifyNoData() throws Exception {
-
-        // simulate successful backend call
-        mockDatadogApiCallAndReturn(enableNotifyNoData(dataDogMonitor("Monitor not OK", DataDogMonitor.STATE_NO_DATA)));
-
-        // execute check
-        final List<CheckResult> checkResults = dataDogCheckExecutor.executeCheck(new DataDogCheck("myCheck", null, null, null, null));
-
-        assertEquals(1, checkResults.size());
-        assertEquals(State.RED, checkResults.get(0).getState());
-        assertEquals("Monitor not OK@DataDog", checkResults.get(0).getName());
-        assertEquals("No Data (query: null)", checkResults.get(0).getInfo());
+        assertEquals(result, checkResults.get(0));
+        assertEquals(result, checkResults.get(1));
     }
 
     @Test
     public void executeCheck_WithNameFiler() throws Exception {
 
         // simulate successful backend call
-        mockDatadogApiCallAndReturn(dataDogMonitor("[YANA]Monitor OK", DataDogMonitor.STATE_OK), dataDogMonitor("Monitor in Error", "some_error_state"));
+        mockServer.expect(requestTo("https://app.datadoghq.com/api/v1/monitor?api_key=apikey&application_key=appkey"))
+                .andExpect(method(HttpMethod.GET))
+                .andRespond(withSuccess("[{\"name\":\"[YANA]Monitor 1\"},{\"name\":\"Monitor 2\"}]", MediaType.APPLICATION_JSON));
+
+        mockDowntimesRestCall();
 
         // execute check with name filter (should work case-insensitive)
-        final List<CheckResult> checkResults = dataDogCheckExecutor.executeCheck(new DataDogCheck("myCheck", null, null, null, "[yana]"));
+        final List<CheckResult> checkResults = dataDogCheckExecutor.executeCheck(check("[yana]"));
 
         assertEquals(1, checkResults.size());
-
-        assertEquals("[YANA]Monitor OK@DataDog", checkResults.get(0).getName());
-        assertEquals("OK (query: null)", checkResults.get(0).getInfo());
+        assertEquals(result, checkResults.get(0));
     }
 
     @Test
     public void executeCheck_WithHttpError() throws Exception {
 
         // simulate some code other than 200
-        mockDatadogApiCallAndReturn(HttpStatus.BAD_GATEWAY);
+        mockServer.expect(requestTo("https://app.datadoghq.com/api/v1/monitor?api_key=apikey&application_key=appkey"))
+                .andExpect(method(HttpMethod.GET))
+                .andRespond(withBadRequest());
+
+        mockDowntimesRestCall();
 
         // execute check
-        final List<CheckResult> checkResults = dataDogCheckExecutor.executeCheck(mock(DataDogCheck.class));
+        final List<CheckResult> checkResults = dataDogCheckExecutor.executeCheck(check(null));
 
         assertEquals(1, checkResults.size());
 
@@ -127,111 +103,16 @@ public class DataDogCheckExecutorTest {
 
         assertEquals(State.RED, checkResult.getState());
         assertEquals("DataDog", checkResult.getName());
-        assertEquals("got http 502", checkResult.getInfo());
+        assertEquals("got http 400", checkResult.getInfo());
     }
 
-    @Test
-    public void convertMonitorToCheckResult() {
-
-        final CheckResult checkResult = dataDogCheckExecutor.convertMonitorToCheckResult(dataDogMonitor("name", DataDogMonitor.STATE_OK), dataDogCheck(), downtimes());
-        assertEquals(State.GREEN, checkResult.getState());
-        assertEquals(1, checkResult.getTestCount());
-        assertEquals(0, checkResult.getFailCount());
-        assertEquals("name@DataDog", checkResult.getName());
-        assertEquals("OK (query: null)", checkResult.getInfo());
-        assertEquals("https://app.datadoghq.com/monitors#status?id=null&group=all", checkResult.getLink());
-        assertNull(checkResult.getGroup());
-        assertNull(checkResult.getTeam());
+    private DataDogCheck check(String nameFilter) {
+        return new DataDogCheck("myCheck", null, "apikey", "appkey", nameFilter);
     }
 
-    @Test
-    public void convertMonitorToCheckResult_Alert() {
-
-        final CheckResult checkResult = dataDogCheckExecutor.convertMonitorToCheckResult(dataDogMonitor("name", "alert"), dataDogCheck(), downtimes());
-        assertEquals(State.RED, checkResult.getState());
-        assertEquals(1, checkResult.getTestCount());
-        assertEquals(1, checkResult.getFailCount());
-        assertEquals("name@DataDog", checkResult.getName());
-        assertEquals("alert (query: null)", checkResult.getInfo());
-        assertEquals("https://app.datadoghq.com/monitors#status?id=null&group=all", checkResult.getLink());
-        assertNull(checkResult.getGroup());
-        assertNull(checkResult.getTeam());
-    }
-
-    @Test
-    public void convertMonitorToCheckResult_Silenced() {
-
-        final CheckResult checkResult = dataDogCheckExecutor.convertMonitorToCheckResult(dataDogMonitor("name", "alert"), dataDogCheck(), downtimes());
-        assertEquals(State.RED, checkResult.getState());
-        assertEquals(1, checkResult.getTestCount());
-        assertEquals(1, checkResult.getFailCount());
-        assertEquals("name@DataDog", checkResult.getName());
-        assertEquals("alert (query: null)", checkResult.getInfo());
-        assertEquals("https://app.datadoghq.com/monitors#status?id=null&group=all", checkResult.getLink());
-        assertNull(checkResult.getGroup());
-        assertNull(checkResult.getTeam());
-    }
-
-    @Test
-    public void convertMonitorToCheckResult_Downtime() {
-        final DataDogDowntimes downtimes = downtimes();
-        doReturn(true).when(downtimes).hasDowntime(any(DataDogMonitor.class));
-
-        final CheckResult checkResult = dataDogCheckExecutor.convertMonitorToCheckResult(dataDogMonitor("name", "alert"), dataDogCheck(), downtimes);
-        assertEquals(State.GREEN, checkResult.getState());
-        assertEquals(1, checkResult.getTestCount());
-        assertEquals(0, checkResult.getFailCount());
-        assertEquals("name@DataDog", checkResult.getName());
-        assertEquals("MAINTENANCE!", checkResult.getInfo());
-        assertEquals("https://app.datadoghq.com/monitors#status?id=null&group=all", checkResult.getLink());
-        assertNull(checkResult.getGroup());
-        assertNull(checkResult.getTeam());
-    }
-
-    @Test
-    public void decideTeam() {
-
-        assertNull(dataDogCheckExecutor.decideTeam("[foo]some_monitor", teamMappings()));
-        assertNull(dataDogCheckExecutor.decideTeam("some_monitor", teamMappings()));
-        assertEquals(TestTeam.INSTANCE, dataDogCheckExecutor.decideTeam("[yana][cm]some_monitor", teamMappings()));
-        assertEquals(TestTeam.INSTANCE, dataDogCheckExecutor.decideTeam("[yana][foo][cm]some_monitor", teamMappings()));
-        assertEquals(TestTeam.INSTANCE, dataDogCheckExecutor.decideTeam("[cm]some_monitor", teamMappings()));
-    }
-
-    private DataDogDowntimes downtimes() {
-        return Mockito.mock(DataDogDowntimes.class);
-    }
-
-    private DataDogCheck dataDogCheck() {
-        return new DataDogCheck("name", null, "apiKey", "appKey", "nameFilter");
-    }
-
-    private DataDogMonitor dataDogMonitor(String name, String stateOk) {
-        DataDogMonitor monitor = new DataDogMonitor();
-        Whitebox.setInternalState(monitor, "name", name);
-        Whitebox.setInternalState(monitor, "overallState", stateOk);
-        return monitor;
-    }
-
-    private DataDogMonitor enableNotifyNoData(DataDogMonitor monitor) {
-        DataDogMonitorOptions options = new DataDogMonitorOptions();
-        Whitebox.setInternalState(options, "notifyNoData", true);
-        Whitebox.setInternalState(monitor, "options", options);
-        return monitor;
-    }
-
-    private Map<String, Team> teamMappings() {
-
-        Map<String, Team> teamMappings = new HashMap<>();
-        teamMappings.put("[cm]", TestTeam.INSTANCE);
-        return teamMappings;
-    }
-
-    private void mockDatadogApiCallAndReturn(DataDogMonitor... monitors) {
-        when(restTemplate.getForEntity(anyString(), eq(DataDogMonitor[].class))).thenReturn(new ResponseEntity<>(monitors, HttpStatus.OK));
-    }
-
-    private void mockDatadogApiCallAndReturn(HttpStatus httpStatus) {
-        when(restTemplate.getForEntity(anyString(), eq(DataDogMonitor[].class))).thenReturn(new ResponseEntity<>(httpStatus));
+    private void mockDowntimesRestCall() {
+        mockServer.expect(requestTo("https://app.datadoghq.com/api/v1/downtime?current_only=true&api_key=apikey&application_key=appkey"))
+                .andExpect(method(HttpMethod.GET))
+                .andRespond(withSuccess("[]", MediaType.APPLICATION_JSON));
     }
 }

--- a/dash-core/src/test/java/de/axelspringer/ideas/tools/dash/business/datadog/monitorresultmapper/DefaultMonitorResultMapperTest.java
+++ b/dash-core/src/test/java/de/axelspringer/ideas/tools/dash/business/datadog/monitorresultmapper/DefaultMonitorResultMapperTest.java
@@ -1,0 +1,130 @@
+package de.axelspringer.ideas.tools.dash.business.datadog.monitorresultmapper;
+
+import de.axelspringer.ideas.tools.dash.business.check.CheckResult;
+import de.axelspringer.ideas.tools.dash.business.datadog.DataDogCheck;
+import de.axelspringer.ideas.tools.dash.business.datadog.DataDogDowntimes;
+import de.axelspringer.ideas.tools.dash.business.datadog.DataDogMonitor;
+import de.axelspringer.ideas.tools.dash.business.datadog.DataDogMonitorOptions;
+import de.axelspringer.ideas.tools.dash.presentation.State;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.mockito.internal.util.reflection.Whitebox;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doReturn;
+
+public class DefaultMonitorResultMapperTest {
+
+    private DefaultMonitorResultMapper resultMapper;
+
+    @Before
+    public void setUp() throws Exception {
+        resultMapper = new DefaultMonitorResultMapper();
+    }
+
+    @Test
+    public void mapToResult() {
+
+        final CheckResult checkResult = resultMapper.mapToResult(dataDogMonitor("name", DataDogMonitor.STATE_OK), dataDogCheck(), downtimes());
+        assertEquals(State.GREEN, checkResult.getState());
+        assertEquals(1, checkResult.getTestCount());
+        assertEquals(0, checkResult.getFailCount());
+        assertEquals("name", checkResult.getName());
+        assertEquals("OK", checkResult.getInfo());
+        assertEquals("https://app.datadoghq.com/monitors#status?id=null&group=all", checkResult.getLink());
+        assertNull(checkResult.getGroup());
+        assertNull(checkResult.getTeam());
+    }
+
+    @Test
+    public void mapToResult_Alert() {
+
+        final CheckResult checkResult = resultMapper.mapToResult(dataDogMonitor("name", "alert"), dataDogCheck(), downtimes());
+        assertEquals(State.RED, checkResult.getState());
+        assertEquals(1, checkResult.getTestCount());
+        assertEquals(1, checkResult.getFailCount());
+        assertEquals("alert", checkResult.getInfo());
+    }
+
+    @Test
+    public void mapToResult_Silenced() {
+
+        final CheckResult checkResult = resultMapper.mapToResult(mute(dataDogMonitor("name", "alert")), dataDogCheck(), downtimes());
+        assertEquals(State.GREEN, checkResult.getState());
+        assertEquals(1, checkResult.getTestCount());
+        assertEquals(0, checkResult.getFailCount());
+        assertEquals("NOT ACTIVE (silenced)!", checkResult.getInfo());
+    }
+
+    @Test
+    public void mapToResult_Downtime() {
+        final DataDogDowntimes downtimes = downtimes();
+        doReturn(true).when(downtimes).hasDowntime(any(DataDogMonitor.class));
+
+        final CheckResult checkResult = resultMapper.mapToResult(dataDogMonitor("name", "alert"), dataDogCheck(), downtimes);
+        assertEquals(State.GREEN, checkResult.getState());
+        assertEquals(1, checkResult.getTestCount());
+        assertEquals(0, checkResult.getFailCount());
+        assertEquals("MAINTENANCE!", checkResult.getInfo());
+    }
+
+    @Test
+    public void mapToResult_noData() throws Exception {
+
+        DataDogMonitor monitor = dataDogMonitor("name", DataDogMonitor.STATE_NO_DATA);
+        final CheckResult checkResult = resultMapper.mapToResult(monitor, dataDogCheck(), downtimes());
+        assertEquals(State.GREEN, checkResult.getState());
+        assertEquals(1, checkResult.getTestCount());
+        assertEquals(0, checkResult.getFailCount());
+        assertEquals("No Data", checkResult.getInfo());
+    }
+
+    @Test
+    public void mapToResult_withNotifyNoData() throws Exception {
+
+        DataDogMonitor monitor = enableNotifyNoData(dataDogMonitor("name", DataDogMonitor.STATE_NO_DATA));
+        final CheckResult checkResult = resultMapper.mapToResult(monitor, dataDogCheck(), downtimes());
+
+        assertEquals(State.RED, checkResult.getState());
+        assertEquals(1, checkResult.getTestCount());
+        assertEquals(1, checkResult.getFailCount());
+        assertEquals("No Data", checkResult.getInfo());
+    }
+
+    private DataDogMonitor dataDogMonitor(String name, String stateOk) {
+        DataDogMonitor monitor = new DataDogMonitor();
+        Whitebox.setInternalState(monitor, "name", name);
+        Whitebox.setInternalState(monitor, "overallState", stateOk);
+        return monitor;
+    }
+
+    private DataDogCheck dataDogCheck() {
+        return new DataDogCheck("name", null, "apiKey", "appKey", "nameFilter");
+    }
+
+    private DataDogDowntimes downtimes() {
+        return Mockito.mock(DataDogDowntimes.class);
+    }
+
+    private DataDogMonitor mute(DataDogMonitor monitor) {
+        DataDogMonitorOptions options = new DataDogMonitorOptions();
+        Map<String, Object> silenced = new HashMap<>();
+        silenced.put("*", null);
+        Whitebox.setInternalState(options, "silenced", silenced);
+        Whitebox.setInternalState(monitor, "options", options);
+        return monitor;
+    }
+
+    private DataDogMonitor enableNotifyNoData(DataDogMonitor monitor) {
+        DataDogMonitorOptions options = new DataDogMonitorOptions();
+        Whitebox.setInternalState(options, "notifyNoData", true);
+        Whitebox.setInternalState(monitor, "options", options);
+        return monitor;
+    }
+}


### PR DESCRIPTION
to be able to customize it to your needs (e.g. set some monitors to ORANGE instead of RED depending on it's criticality). The team mapping functionality was removed as this can now be solved via the custom mapper too.

For #54

If this is ok, i will prepare the yana-dash because of this non-backwards compatible change (team mapping must be changed) before we should merge this