### PR TITLE
allow to hide empty groups

### DIFF
--- a/dash-core/src/main/resources/static/dash.js
+++ b/dash-core/src/main/resources/static/dash.js
@@ -16,6 +16,7 @@ angular.module('dash', ['ngResource', 'ngSanitize'])
                 teams: {},
                 aggregate: true,
                 aggregateDuplicated: true,
+                showEmptyGroups: true,
                 hue: {}
             }, $scope.config);
 
@@ -195,6 +196,9 @@ angular.module('dash', ['ngResource', 'ngSanitize'])
 
             var fillEmptyWithGreen = function (group) {
 
+                if (!$scope.config.showEmptyGroups) {
+                    return;
+                }
                 if (group.checks.length < 1) {
                     group.checks.push({
                         name: 'F-I-N-E',

--- a/dash-core/src/main/resources/static/index.html
+++ b/dash-core/src/main/resources/static/index.html
@@ -28,7 +28,8 @@
     <div class="global-info" ng-class="{true: 'alert-danger'}[lastUpdate.state == 'red']">Last update: {{ infos.lastUpdateTime | date:'medium' }}</div>
 
     <div class="panel-body">
-        <div ng-repeat="group in infos.groups | orderBy:'orderScore'" class="check-group panel">
+        <div ng-repeat="group in infos.groups | orderBy:'orderScore'" class="check-group panel"
+             ng-show="group.checks.length">
             <div class="panel-body">
                 <div class="stage-info {{ groupClass(group) }}">
                     <div class="check-name">{{ group.name }}</div>
@@ -63,6 +64,9 @@
 
     <label class="team-label">
         <input type="checkbox" ng-model="config.aggregate" ng-click="loadInfos()"/> aggregate green checks
+    </label>
+    <label class="team-label">
+        <input type="checkbox" ng-model="config.showEmptyGroups" ng-click="loadInfos()"/> show empty groups
     </label>
     <label class="team-label">
         <input type="checkbox" ng-model="config.aggregateDuplicated" ng-click="loadInfos()"/> aggregate duplicated checks


### PR DESCRIPTION
i want to use the same yana-dash instance for regular dashing and pipeline support but dont want to show the empty groups (like monitoring and so) on the pipeline-tvs...