### PR TITLE
Only fetch build info if it was requested

### DIFF
--- a/dash-core/src/main/java/de/axelspringer/ideas/tools/dash/business/jenkins/JenkinsCheck.java
+++ b/dash-core/src/main/java/de/axelspringer/ideas/tools/dash/business/jenkins/JenkinsCheck.java
@@ -69,8 +69,4 @@ public class JenkinsCheck extends Check {
     public boolean isFetchBuildInfo() {
         return fetchBuildInfo;
     }
-
-    public void setFetchBuildInfo(boolean fetchBuildInfo) {
-        this.fetchBuildInfo = fetchBuildInfo;
-    }
 }

--- a/dash-core/src/main/java/de/axelspringer/ideas/tools/dash/business/jenkins/JenkinsCheck.java
+++ b/dash-core/src/main/java/de/axelspringer/ideas/tools/dash/business/jenkins/JenkinsCheck.java
@@ -17,6 +17,8 @@ public class JenkinsCheck extends Check {
 
     private final String jobUrl;
 
+    private boolean fetchBuildInfo = false;
+
     public JenkinsCheck(String name, String url, String userName, String apiToken, Group group, List<Team> teams, JenkinsJobNameMapper jenkinsJobNameMapper) {
         super(name, group, teams);
         this.jobUrl = url;
@@ -46,6 +48,11 @@ public class JenkinsCheck extends Check {
         return this;
     }
 
+    public JenkinsCheck withFetchBuildInfo(boolean fetchBuildInfo) {
+        this.fetchBuildInfo = fetchBuildInfo;
+        return this;
+    }
+
     public JenkinsServerConfiguration getServerConfiguration() {
         return serverConfiguration;
     }
@@ -57,5 +64,13 @@ public class JenkinsCheck extends Check {
     @Override
     public String getIconSrc() {
         return ICON_SRC;
+    }
+
+    public boolean isFetchBuildInfo() {
+        return fetchBuildInfo;
+    }
+
+    public void setFetchBuildInfo(boolean fetchBuildInfo) {
+        this.fetchBuildInfo = fetchBuildInfo;
     }
 }

--- a/dash-core/src/main/java/de/axelspringer/ideas/tools/dash/business/jenkins/executor/JenkinsCheckExecutor.java
+++ b/dash-core/src/main/java/de/axelspringer/ideas/tools/dash/business/jenkins/executor/JenkinsCheckExecutor.java
@@ -50,7 +50,7 @@ public class JenkinsCheckExecutor implements CheckExecutor<JenkinsCheck> {
                             .withTeams(check.getTeams()));
         }
 
-        final BuildInfo buildInfo = buildInfo(check.getJobUrl(), serverConfiguration);
+        final BuildInfo buildInfo = check.isFetchBuildInfo() ? buildInfo(check.getJobUrl(), serverConfiguration) : new BuildInfo();
 
         if (jobInfo.isPipeline()) {
             return pipelineExecutor.executeCheck(jobInfo, check, buildInfo);


### PR DESCRIPTION
There are a lot of 404 errors in the log when jobs are checked that do not have a build_info.json artifact