### PR TITLE
Option Explode Pipelines

### DIFF
--- a/dash-core/src/main/java/de/axelspringer/ideas/tools/dash/business/jenkins/JenkinsCheck.java
+++ b/dash-core/src/main/java/de/axelspringer/ideas/tools/dash/business/jenkins/JenkinsCheck.java
@@ -19,6 +19,11 @@ public class JenkinsCheck extends Check {
 
     private boolean fetchBuildInfo = false;
 
+    /**
+     * determines if a pipeline should be represented by one checkresult or several (one per stage in pipeline)
+     */
+    private boolean explodePipelines = true;
+
     public JenkinsCheck(String name, String url, String userName, String apiToken, Group group, List<Team> teams, JenkinsJobNameMapper jenkinsJobNameMapper) {
         super(name, group, teams);
         this.jobUrl = url;
@@ -56,6 +61,19 @@ public class JenkinsCheck extends Check {
 
     public JenkinsCheck withFetchBuildInfo(boolean fetchBuildInfo) {
         this.fetchBuildInfo = fetchBuildInfo;
+        return this;
+    }
+
+    public boolean isExplodePipelines() {
+        return explodePipelines;
+    }
+
+    /**
+     * @param explodePipelines {@link #explodePipelines}
+     * @return this {@link JenkinsCheck} instance
+     */
+    public JenkinsCheck withExplodePipelines(boolean explodePipelines) {
+        this.explodePipelines = explodePipelines;
         return this;
     }
 

--- a/dash-core/src/main/java/de/axelspringer/ideas/tools/dash/business/jenkins/executor/JenkinsCheckExecutor.java
+++ b/dash-core/src/main/java/de/axelspringer/ideas/tools/dash/business/jenkins/executor/JenkinsCheckExecutor.java
@@ -52,7 +52,7 @@ public class JenkinsCheckExecutor implements CheckExecutor<JenkinsCheck> {
 
         final BuildInfo buildInfo = check.isFetchBuildInfo() ? buildInfo(check.getJobUrl(), serverConfiguration) : new BuildInfo();
 
-        if (jobInfo.isPipeline()) {
+        if (jobInfo.isPipeline() && check.isExplodePipelines()) {
             return pipelineExecutor.executeCheck(jobInfo, check, buildInfo);
         }
         return jobExecutor.executeCheck(jobInfo, check, buildInfo);

--- a/dash-core/src/main/java/de/axelspringer/ideas/tools/dash/business/jenkins/joblist/JenkinsJobListCheckProvider.java
+++ b/dash-core/src/main/java/de/axelspringer/ideas/tools/dash/business/jenkins/joblist/JenkinsJobListCheckProvider.java
@@ -136,7 +136,8 @@ public class JenkinsJobListCheckProvider implements CheckProvider {
         }
 
         return new JenkinsCheck(jobName, job.getUrl(), serverConfig, group, teams)
-                .withJobNameMapper(jenkinsJobNameMapper);
+                .withJobNameMapper(jenkinsJobNameMapper)
+                .withExplodePipelines(false);
     }
 
     private List<JenkinsElement> jobs(String url) {


### PR DESCRIPTION
Optionally handle pipelines as regular Jenkins Jobs (exploding to pipeline stages does not make sense if a pipeline is not represented in a single group)

Also make JenkinsJobListCheckProvider.java provide condensed pipelines as default.