### PR TITLE
Switch cloudwatch to use the AWS default chain provider

### DIFF
--- a/dash-core/src/main/java/de/axelspringer/ideas/tools/dash/business/cloudwatch/CloudWatchCheck.java
+++ b/dash-core/src/main/java/de/axelspringer/ideas/tools/dash/business/cloudwatch/CloudWatchCheck.java
@@ -11,19 +11,14 @@ import java.util.List;
  */
 public class CloudWatchCheck extends Check {
 
-    private final String awsAccessKeyId;
-    private final String awsSecretKey;
     private final String awsRegion;
 
     public CloudWatchCheck(
             String name,
             Group group,
             List<Team> teams,
-            String awsAccessKeyId,
-            String awsSecretKey, String awsRegion) {
+            String awsRegion) {
         super(name, group, teams);
-        this.awsAccessKeyId = awsAccessKeyId;
-        this.awsSecretKey = awsSecretKey;
         this.awsRegion = awsRegion;
     }
 
@@ -31,11 +26,4 @@ public class CloudWatchCheck extends Check {
         return awsRegion;
     }
 
-    public String getAwsAccessKeyId() {
-        return awsAccessKeyId;
-    }
-
-    public String getAwsSecretKey() {
-        return awsSecretKey;
-    }
 }

--- a/dash-core/src/main/java/de/axelspringer/ideas/tools/dash/business/cloudwatch/CloudWatchCheckExecutor.java
+++ b/dash-core/src/main/java/de/axelspringer/ideas/tools/dash/business/cloudwatch/CloudWatchCheckExecutor.java
@@ -26,8 +26,6 @@ public class CloudWatchCheckExecutor implements CheckExecutor<CloudWatchCheck> {
     @Override
     public List<CheckResult> executeCheck(final CloudWatchCheck check) {
         return cloudWatchService.describeAlarms(
-                check.getAwsAccessKeyId(),
-                check.getAwsSecretKey(),
                 check.getAwsRegion())
                 .getMetricAlarms()
                 .parallelStream().map(v -> factorCheckResult(v, check))

--- a/dash-core/src/main/java/de/axelspringer/ideas/tools/dash/business/cloudwatch/CloudWatchService.java
+++ b/dash-core/src/main/java/de/axelspringer/ideas/tools/dash/business/cloudwatch/CloudWatchService.java
@@ -1,9 +1,7 @@
 package de.axelspringer.ideas.tools.dash.business.cloudwatch;
 
-import com.amazonaws.auth.AWSCredentials;
-import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
-import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
 import com.amazonaws.services.cloudwatch.AmazonCloudWatchClientBuilder;
 import com.amazonaws.services.cloudwatch.model.DescribeAlarmsResult;
 import org.springframework.stereotype.Service;
@@ -11,10 +9,10 @@ import org.springframework.stereotype.Service;
 @Service
 public class CloudWatchService {
 
-    public DescribeAlarmsResult describeAlarms(String awsAccessKeyId, String awsSecretKey, String awsRegion) {
+    public DescribeAlarmsResult describeAlarms(String awsRegion) {
 
-        final AWSCredentials credentials = new BasicAWSCredentials(awsAccessKeyId, awsSecretKey);
-        final AWSCredentialsProvider credentialProvider = new AWSStaticCredentialsProvider(credentials);
+        final DefaultAWSCredentialsProviderChain credentialsProviderChain = new DefaultAWSCredentialsProviderChain();
+        final AWSStaticCredentialsProvider credentialProvider = new AWSStaticCredentialsProvider(credentialsProviderChain.getCredentials());
         return AmazonCloudWatchClientBuilder
                 .standard()
                 .withCredentials(credentialProvider)

--- a/dash-core/src/main/java/de/axelspringer/ideas/tools/dash/business/cloudwatch/CloudWatchService.java
+++ b/dash-core/src/main/java/de/axelspringer/ideas/tools/dash/business/cloudwatch/CloudWatchService.java
@@ -1,7 +1,5 @@
 package de.axelspringer.ideas.tools.dash.business.cloudwatch;
 
-import com.amazonaws.auth.AWSStaticCredentialsProvider;
-import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
 import com.amazonaws.services.cloudwatch.AmazonCloudWatchClientBuilder;
 import com.amazonaws.services.cloudwatch.model.DescribeAlarmsResult;
 import org.springframework.stereotype.Service;
@@ -11,11 +9,8 @@ public class CloudWatchService {
 
     public DescribeAlarmsResult describeAlarms(String awsRegion) {
 
-        final DefaultAWSCredentialsProviderChain credentialsProviderChain = new DefaultAWSCredentialsProviderChain();
-        final AWSStaticCredentialsProvider credentialProvider = new AWSStaticCredentialsProvider(credentialsProviderChain.getCredentials());
         return AmazonCloudWatchClientBuilder
                 .standard()
-                .withCredentials(credentialProvider)
                 .withRegion(awsRegion)
                 .build()
                 .describeAlarms();


### PR DESCRIPTION
The basic AWS provider only provides support for hardcoded credentials
to be passed to the library. We'd like to switch to using the
DefaultCredentialProviderChain instead. This will search for AWS
credentials in the following paths:

- Environment Variables - AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY
- Java System Properties - aws.accessKeyId and aws.secretKey
- Credential profiles file at the default location (~/.aws/credentials)
- Credentials delivered through the Amazon EC2 container service
- Instance profile credentials delivered through the Amazon EC2 metadata
service

The client will automatically default to this provider. No explicit configuration is needed