### PR TITLE
add generic customize method to JiraIssueCheckResultDecorator

### DIFF
--- a/dash-core/src/main/java/de/axelspringer/ideas/tools/dash/business/check/checkresult/CheckResult.java
+++ b/dash-core/src/main/java/de/axelspringer/ideas/tools/dash/business/check/checkresult/CheckResult.java
@@ -76,7 +76,7 @@ public class CheckResult {
         return this;
     }
 
-    public CheckResult withTeams(List<Team> teams) {
+    public CheckResult withTeams(List<? extends Team> teams) {
 
         if (teams != null) {
             teams.forEach(team -> {

--- a/dash-core/src/main/java/de/axelspringer/ideas/tools/dash/business/jira/JiraCheckExecutor.java
+++ b/dash-core/src/main/java/de/axelspringer/ideas/tools/dash/business/jira/JiraCheckExecutor.java
@@ -12,10 +12,11 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+
+import static java.util.stream.Collectors.toList;
 
 @Service
 public class JiraCheckExecutor implements CheckExecutor<JiraCheck> {
@@ -53,14 +54,9 @@ public class JiraCheckExecutor implements CheckExecutor<JiraCheck> {
             return Collections.singletonList(checkResult);
         }
 
-        List<CheckResult> checkResults = new ArrayList<>();
-
-        for (Issue issue : issues) {
-            CheckResult checkResult = createCheckResultForIssue(jiraCheck, issue);
-            checkResults.add(checkResult);
-        }
-
-        return checkResults;
+        return issues.stream()
+                .map(issue -> createCheckResultForIssue(jiraCheck, issue))
+                .collect(toList());
     }
 
     CheckResult createCheckResultForIssue(JiraCheck jiraCheck, Issue issue) {

--- a/dash-core/src/main/java/de/axelspringer/ideas/tools/dash/business/jira/JiraCheckExecutor.java
+++ b/dash-core/src/main/java/de/axelspringer/ideas/tools/dash/business/jira/JiraCheckExecutor.java
@@ -68,14 +68,15 @@ public class JiraCheckExecutor implements CheckExecutor<JiraCheck> {
         final String info = checkResultDecorator.info(issue);
 
         final CheckResult checkResult = new CheckResult(state, name, info, 1, state == State.GREEN ? 0 : 1, jiraCheck.getGroup())
-                .withLink(jiraCheck.getUrl() + "/browse/" + issue.getKey()).withTeams(jiraCheck.getTeams())
+                .withLink(jiraCheck.getUrl() + "/browse/" + issue.getKey())
+                .withTeams(jiraCheck.getTeams())
                 .withCheckResultIdentifier(jiraCheck.getUrl() + "_" + issue.getKey());
 
         if (jiraProjectConfiguration.isIssueInProgress(issue)) {
             checkResult.markRunning();
         }
 
-        return checkResult;
+        return checkResultDecorator.decorate(checkResult, jiraCheck, issue);
     }
 
     @Override

--- a/dash-core/src/main/java/de/axelspringer/ideas/tools/dash/business/jira/issuecheckresultdecorator/JiraIssueCheckResultDecorator.java
+++ b/dash-core/src/main/java/de/axelspringer/ideas/tools/dash/business/jira/issuecheckresultdecorator/JiraIssueCheckResultDecorator.java
@@ -1,5 +1,6 @@
 package de.axelspringer.ideas.tools.dash.business.jira.issuecheckresultdecorator;
 
+import de.axelspringer.ideas.tools.dash.business.check.checkresult.CheckResult;
 import de.axelspringer.ideas.tools.dash.business.jira.JiraCheck;
 import de.axelspringer.ideas.tools.dash.business.jira.rest.Issue;
 
@@ -11,4 +12,8 @@ public interface JiraIssueCheckResultDecorator {
     String info(Issue issue);
 
     String name(JiraCheck jiraCheck, Issue issue);
+
+    default CheckResult decorate(CheckResult checkResult, JiraCheck jiraCheck, Issue issue) {
+        return checkResult;
+    };
 }

--- a/dash-core/src/main/java/de/axelspringer/ideas/tools/dash/business/jira/rest/Fields.java
+++ b/dash-core/src/main/java/de/axelspringer/ideas/tools/dash/business/jira/rest/Fields.java
@@ -21,6 +21,7 @@ public class Fields {
      * Team
      */
     private CustomField customfield_10144;
+    private CustomField customfield_11400;
 
     private Assignee assignee;
 
@@ -67,6 +68,14 @@ public class Fields {
 
     public void setCustomfield_10144(CustomField customfield_10144) {
         this.customfield_10144 = customfield_10144;
+    }
+
+    public CustomField getCustomfield_11400() {
+        return customfield_11400;
+    }
+
+    public void setCustomfield_11400(CustomField customfield_11400) {
+        this.customfield_11400 = customfield_11400;
     }
 
     public Assignee getAssignee() {


### PR DESCRIPTION
to have maximum freedom for customizability without having to adapt
dash-core all the time.

In our example we want to read all jira issues and then apply teams
instead of creating one check for each team. Advantage then is that
issues without any team would also be displayed and less jira API calls
are needed if you have many teams