### PR TITLE
Cloudwatch team mapper

### DIFF
--- a/dash-core/src/main/java/de/axelspringer/ideas/tools/dash/business/check/checkresult/CheckResult.java
+++ b/dash-core/src/main/java/de/axelspringer/ideas/tools/dash/business/check/checkresult/CheckResult.java
@@ -88,6 +88,11 @@ public class CheckResult {
         return this;
     }
 
+    public CheckResult withTeamNames(List<String> teamNames) {
+        this.teams.addAll(teamNames);
+        return this;
+    }
+
     public CheckResult withName(String name) {
         this.name = name;
         return this;
@@ -115,6 +120,10 @@ public class CheckResult {
 
     public State getState() {
         return this.state;
+    }
+
+    public void setState(State state) {
+        this.state = state;
     }
 
     public String getName() {

--- a/dash-core/src/main/java/de/axelspringer/ideas/tools/dash/business/cloudwatch/CloudWatchCheckExecutor.java
+++ b/dash-core/src/main/java/de/axelspringer/ideas/tools/dash/business/cloudwatch/CloudWatchCheckExecutor.java
@@ -23,6 +23,9 @@ public class CloudWatchCheckExecutor implements CheckExecutor<CloudWatchCheck> {
     @Autowired
     private CloudWatchStateMapper stateMapper;
 
+    @Autowired
+    private CloudWatchTeamMapper teamMapper;
+
     @Override
     public List<CheckResult> executeCheck(final CloudWatchCheck check) {
 
@@ -46,16 +49,15 @@ public class CloudWatchCheckExecutor implements CheckExecutor<CloudWatchCheck> {
         final String name = metricAlarm.getAlarmName();
         final String info = metricAlarm.getAlarmDescription();
 
-        CheckResult checkResult = new CheckResult(
+        return new CheckResult(
                 state,
                 name,
                 info,
                 1,
                 state == State.GREEN ? 0 : 1,
-                check.getGroup()
-        );
-
-        return checkResult.withCheckResultIdentifier(check.getRegion() + "_" + name);
+                check.getGroup())
+                .withCheckResultIdentifier(check.getRegion() + "_" + name)
+                .withTeamNames(teamMapper.map(metricAlarm));
     }
 
     @Override

--- a/dash-core/src/main/java/de/axelspringer/ideas/tools/dash/business/cloudwatch/CloudWatchConfig.java
+++ b/dash-core/src/main/java/de/axelspringer/ideas/tools/dash/business/cloudwatch/CloudWatchConfig.java
@@ -3,8 +3,10 @@ package de.axelspringer.ideas.tools.dash.business.cloudwatch;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 
 @Configuration
+@Import({CloudwatchProperties.class})
 public class CloudWatchConfig {
 
     @ConditionalOnMissingBean

--- a/dash-core/src/main/java/de/axelspringer/ideas/tools/dash/business/cloudwatch/CloudWatchTeamMapper.java
+++ b/dash-core/src/main/java/de/axelspringer/ideas/tools/dash/business/cloudwatch/CloudWatchTeamMapper.java
@@ -1,0 +1,57 @@
+package de.axelspringer.ideas.tools.dash.business.cloudwatch;
+
+import com.amazonaws.services.cloudwatch.model.MetricAlarm;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import static java.util.Collections.emptyList;
+import static java.util.stream.Collectors.toList;
+
+@Component
+public class CloudWatchTeamMapper {
+
+    @Autowired
+    private CloudwatchProperties properties;
+
+    private ConcurrentHashMap<String, Pattern> patternCache = new ConcurrentHashMap<>();
+
+    public List<String> map(MetricAlarm metricAlarm) {
+        if (properties.getAlarmToTeamsMapping() == null) {
+            return emptyList();
+        }
+
+        String alarmName = metricAlarm.getAlarmName();
+
+        return properties.getAlarmToTeamsMapping().entrySet().stream()
+                .flatMap(entry -> mapToTeam(entry, alarmName))
+                .distinct()
+                .collect(toList());
+    }
+
+    private Stream<String> mapToTeam(Map.Entry<String, List<String>> regexesForTeam, String alarmName) {
+        String team = regexesForTeam.getKey();
+        List<String> regexes = regexesForTeam.getValue();
+
+        boolean matches = regexes.stream().anyMatch(regex -> {
+            Pattern pattern = compileOrGetCachedPattern(regex);
+
+            return pattern.matcher(alarmName).matches();
+        });
+
+        if (matches) {
+            return Stream.of(team);
+        } else {
+            return Stream.empty();
+        }
+    }
+
+    private Pattern compileOrGetCachedPattern(String regex) {
+        return patternCache.computeIfAbsent(regex, Pattern::compile);
+    }
+}

--- a/dash-core/src/main/java/de/axelspringer/ideas/tools/dash/business/cloudwatch/CloudwatchProperties.java
+++ b/dash-core/src/main/java/de/axelspringer/ideas/tools/dash/business/cloudwatch/CloudwatchProperties.java
@@ -1,0 +1,22 @@
+package de.axelspringer.ideas.tools.dash.business.cloudwatch;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+import java.util.Map;
+
+@Configuration
+@ConfigurationProperties(prefix = "dash.cloudwatch")
+public class CloudwatchProperties {
+
+    private Map<String, List<String>> alarmToTeamsMapping;
+
+    public Map<String, List<String>> getAlarmToTeamsMapping() {
+        return alarmToTeamsMapping;
+    }
+
+    public void setAlarmToTeamsMapping(Map<String, List<String>> alarmToTeamsMapping) {
+        this.alarmToTeamsMapping = alarmToTeamsMapping;
+    }
+}


### PR DESCRIPTION
can be configured as follows:
```
dash:
  cloudwatch.alarm-to-teams-mapping:
    TeamA:
      - '.*bla.*'
      - '.*foo\-service.*'
    TeamB:
      - '.*bar\-service*'
```