### PR TITLE
hue config now contains a URL instead of ip address

### DIFF
--- a/dash-core/src/main/resources/static/app/dash/options/options.html
+++ b/dash-core/src/main/resources/static/app/dash/options/options.html
@@ -9,7 +9,7 @@
     <label class="team-label">
         <input type="checkbox" ng-model="config.hue.enabled"/> hue
         <div ng-show="config.hue.enabled">
-            ip <input type="text" size="12" ng-model="config.hue.ip">
+            URL <input type="text" size="12" ng-model="config.hue.url">
             key <input type="text" size="12" ng-model="config.hue.key">
             light# <input type="text" size="5" ng-model="config.hue.light">
         </div>

--- a/dash-core/src/main/resources/static/app/services/persistence.js
+++ b/dash-core/src/main/resources/static/app/services/persistence.js
@@ -1,3 +1,4 @@
+(function() {
 /**
  * Service that helps interacting with browser local storage
  */
@@ -10,6 +11,7 @@ angular.module('dashapp')
                 throw "go get a proper browser that supports local storage!";
             }
             var data = storage['data'] ? JSON.parse(storage['data']) : {};
+            data = migrateConfig(data)
 
             var persist = function () {
                 storage['data'] = JSON.stringify(data);
@@ -45,18 +47,29 @@ angular.module('dashapp')
                 persist();
             };
 
-        persistenceService.load = function (key, defaultValue) {
-            if (!data[key]) {
-                return defaultValue;
-            }
-            return data[key];
-        };
+            persistenceService.load = function (key, defaultValue) {
+                if (!data[key]) {
+                    return defaultValue;
+                }
+                return data[key];
+            };
 
-        persistenceService.save = function (key, value) {
-            data[key] = value;
-            persist();
-        };
+            persistenceService.save = function (key, value) {
+                data[key] = value;
+                persist();
+            };
 
             return persistenceService;
         }
     );
+
+function migrateConfig(config) {
+    var hue = config.hue || {};
+    if (hue.ip) {
+        hue.url = 'http://' + hue.ip;
+        delete hue.ip;
+    }
+    return config;
+}
+
+})();

--- a/dash-core/src/main/resources/static/app/services/philipshue.js
+++ b/dash-core/src/main/resources/static/app/services/philipshue.js
@@ -14,13 +14,13 @@ angular.module('dashapp')
             hueService.update = function (hueConfig, data) {
 
                 // check params
-                if (!hueConfig.ip || !hueConfig.key || !hueConfig.light || !data) {
+                if (!hueConfig.url || !hueConfig.key || !hueConfig.light || !data) {
                     console.error("invalid parameters, cannot update hue");
                     return;
                 }
 
                 hueConfig.light.split(',').forEach(light => {
-                    var hueResource = $resource("http://" + hueConfig['ip'] + "/api/" + hueConfig['key'] + "/lights/" + light + "/state", null, {
+                    var hueResource = $resource(hueConfig['url'] + "/api/" + hueConfig['key'] + "/lights/" + light + "/state", null, {
                         'update': {
                             method: 'PUT',
                             isArray: true

--- a/dash-core/src/main/resources/static/app/services/philipshue.js
+++ b/dash-core/src/main/resources/static/app/services/philipshue.js
@@ -20,14 +20,28 @@ angular.module('dashapp')
                 }
 
                 hueConfig.light.split(',').forEach(light => {
-                    var hueResource = $resource(hueConfig['url'] + "/api/" + hueConfig['key'] + "/lights/" + light + "/state", null, {
+                    var url = hueConfig['url'] + "/api/" + hueConfig['key'] + "/lights/" + light + "/state";
+
+                    var hueResource = $resource(url, null, {
                         'update': {
                             method: 'PUT',
-                            isArray: true
+                            isArray: true,
+                            headers: {
+                                Authorization: extractBasicAuthHeaderFromUrl(url)
+                            }
                         }
                     });
                     hueResource.update(data);
                 })
+            };
+
+            var extractBasicAuthHeaderFromUrl = function(url) {
+                var match = /^(.+?\/\/)(?<username>.+?):(?<password>.+?)@(.+)$/.exec(url);
+                if (match) {
+                    var credentials = match.groups;
+                    return 'Basic ' + btoa(credentials.username + ':' + credentials.password);
+                }
+                return undefined;
             };
 
             return hueService;


### PR DESCRIPTION
we want to use https to communicate with the hue bridge to get rid of
browser alerts and always having to tick "load insecure scripts"

Additionally, support basic auth credentials in the URL as an additional layer of security. Not sure how secure the hue API is with its API keys